### PR TITLE
Fix templating variables not returning array

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -43,8 +43,8 @@ export class Warp10Datasource {
   }
 
   parseTemplatingResult(o) {
-    console.debug('tesmplating result', o);
-    return o.data.map((data, indice) => {
+    console.debug('templating result', o);
+    return o.data[0].map((data, indice) => {
       return {text: data.toString() || indice, value: data};
     });
   }


### PR DESCRIPTION
Hi,

The code uses data[0] everywhere expect when parsing the result for the variables query.

Before: a single variable, with the list joined by ","
After: multiple variables in the dropdown.

