### PR TITLE
Fix annotation tags and `All` values for Grafana 5.4+

### DIFF
--- a/dist/warp10-datasource.js
+++ b/dist/warp10-datasource.js
@@ -262,13 +262,12 @@ System.register(["./gts", "./table", "./geo", "./query"], function (exports_1, c
                     for (var _i = 0, _a = this.templateSrv.variables; _i < _a.length; _i++) {
                         var myVar = _a[_i];
                         var value = myVar.current.text;
-                        if (myVar.current.value.length === 1 && myVar.current.value[0] === '$__all')
-			{
-			    if (myVar.allValue)
+                        if (myVar.current.value.length === 1 && myVar.current.value[0] === '$__all') {
+                            if (myVar.allValue !== null)
                                 value = myVar.allValue;
-			    else
-				value = myVar.options.slice(1).map(function (e) { return e.text; }).join(" + ");
-			}
+                            else
+                                value = myVar.options.slice(1).map(function (e) { return e.text; }).join(" + ");
+                        }
                         if (isNaN(value) || value.startsWith('0'))
                             value = "'" + value + "'";
                         wsHeader += (value || 'NULL') + " '" + myVar.name + "' STORE ";

--- a/dist/warp10-datasource.js
+++ b/dist/warp10-datasource.js
@@ -262,8 +262,11 @@ System.register(["./gts", "./table", "./geo", "./query"], function (exports_1, c
                     for (var _i = 0, _a = this.templateSrv.variables; _i < _a.length; _i++) {
                         var myVar = _a[_i];
                         var value = myVar.current.text;
-                        if (myVar.current.value === '$__all' && myVar.allValue !== null)
-                            value = myVar.allValue;
+                        if (myVar.current.value.length === 1 && myVar.current.value[0] === '$__all')
+			    if (myVar.allValue)
+                                value = myVar.allValue;
+			    else
+				value = myVar.options.slice(1).map(function (e) { return e.text; }).join(" + ");
                         if (isNaN(value) || value.startsWith('0'))
                             value = "'" + value + "'";
                         wsHeader += (value || 'NULL') + " '" + myVar.name + "' STORE ";

--- a/dist/warp10-datasource.js
+++ b/dist/warp10-datasource.js
@@ -263,10 +263,12 @@ System.register(["./gts", "./table", "./geo", "./query"], function (exports_1, c
                         var myVar = _a[_i];
                         var value = myVar.current.text;
                         if (myVar.current.value.length === 1 && myVar.current.value[0] === '$__all')
+			{
 			    if (myVar.allValue)
                                 value = myVar.allValue;
 			    else
 				value = myVar.options.slice(1).map(function (e) { return e.text; }).join(" + ");
+			}
                         if (isNaN(value) || value.startsWith('0'))
                             value = "'" + value + "'";
                         wsHeader += (value || 'NULL') + " '" + myVar.name + "' STORE ";

--- a/dist/warp10-datasource.js
+++ b/dist/warp10-datasource.js
@@ -160,7 +160,7 @@ System.register(["./gts", "./table", "./geo", "./query"], function (exports_1, c
                                     title: gts.c,
                                     time: Math.trunc(dp[0] / (1000)),
                                     text: dp[dp.length - 1],
-                                    tags: (tags.length > 0) ? tags.join(',') : null
+                                    tags: tags
                                 });
                             });
                         };
@@ -307,7 +307,7 @@ System.register(["./gts", "./table", "./geo", "./query"], function (exports_1, c
                 Warp10Datasource.prototype.scopedVarIsAll = function (name) {
                     for (var i = 0; i < this.templateSrv.variables.length; i++) {
                         var v = this.templateSrv.variables[i];
-                        if (v.name === name && v.current.value === '$__all') {
+                        if (v.name === name && v.current.value.length === 1 && v.current.value[0] === '$__all') {
                             return true;
                         }
                     }

--- a/src/warp10-datasource.ts
+++ b/src/warp10-datasource.ts
@@ -163,7 +163,7 @@ export default class Warp10Datasource {
               title: gts.c,
               time: Math.trunc(dp[0] / (1000)),
               text: dp[dp.length - 1],
-              tags: (tags.length > 0) ? tags.join(',') : null
+              tags: tags
             })
           })
         }

--- a/src/warp10-datasource.ts
+++ b/src/warp10-datasource.ts
@@ -313,7 +313,7 @@ export default class Warp10Datasource {
   private scopedVarIsAll(name: string): boolean {
     for (let i = 0; i < this.templateSrv.variables.length; i++) {
       const v = this.templateSrv.variables[i]
-      if (v.name === name && v.current.value === '$__all') {
+      if (v.name === name && v.current.value.length === 1 && v.current.value[0] === '$__all') {
         return true
       }
     }

--- a/src/warp10-datasource.ts
+++ b/src/warp10-datasource.ts
@@ -264,10 +264,10 @@ export default class Warp10Datasource {
 
       if (myVar.current.value.length === 1 && myVar.current.value[0] === '$__all')
       {
-        if (myVar.allValue)
-	  value = myVar.allValue;
+        if (myVar.allValue !== null)
+          value = myVar.allValue;
         else
-	  value = myVar.options.slice(1).map(e => e.text).join(" + ");
+          value = myVar.options.slice(1).map(e => e.text).join(" + ");
       }
 
       if (isNaN(value) || value.startsWith('0'))

--- a/src/warp10-datasource.ts
+++ b/src/warp10-datasource.ts
@@ -262,8 +262,13 @@ export default class Warp10Datasource {
     for (let myVar of this.templateSrv.variables) {
       let value = myVar.current.text
 
-      if (myVar.current.value === '$__all' && myVar.allValue !== null)
-        value = myVar.allValue
+      if (myVar.current.value.length === 1 && myVar.current.value[0] === '$__all')
+      {
+        if (myVar.allValue)
+	  value = myVar.allValue;
+        else
+	  value = myVar.options.slice(1).map(e => e.text).join(" + ");
+      }
 
       if (isNaN(value) || value.startsWith('0'))
         value = `'${value}'`


### PR DESCRIPTION
The way Grafana deals with both of these change in Grafana 5: the tags are expected to be in a list and the `$_all` value is now the first element of a list of length 1. These commits lead to the expected behaviour.