### PR TITLE
Restore support for single $__all value

### DIFF
--- a/dist/warp10-datasource.js
+++ b/dist/warp10-datasource.js
@@ -262,7 +262,7 @@ System.register(["./gts", "./table", "./geo", "./query"], function (exports_1, c
                     for (var _i = 0, _a = this.templateSrv.variables; _i < _a.length; _i++) {
                         var myVar = _a[_i];
                         var value = myVar.current.text;
-                        if (myVar.current.value.length === 1 && myVar.current.value[0] === '$__all') {
+                        if (myVar.current.value === '$__all' || myVar.current.value.length === 1 && myVar.current.value[0] === '$__all') {
                             if (myVar.allValue !== null)
                                 value = myVar.allValue;
                             else
@@ -311,7 +311,7 @@ System.register(["./gts", "./table", "./geo", "./query"], function (exports_1, c
                 Warp10Datasource.prototype.scopedVarIsAll = function (name) {
                     for (var i = 0; i < this.templateSrv.variables.length; i++) {
                         var v = this.templateSrv.variables[i];
-                        if (v.name === name && v.current.value.length === 1 && v.current.value[0] === '$__all') {
+                        if (v.current.value === '$__all' || v.name === name && v.current.value.length === 1 && v.current.value[0] === '$__all') {
                             return true;
                         }
                     }

--- a/src/warp10-datasource.ts
+++ b/src/warp10-datasource.ts
@@ -262,7 +262,7 @@ export default class Warp10Datasource {
     for (let myVar of this.templateSrv.variables) {
       let value = myVar.current.text
 
-      if (myVar.current.value.length === 1 && myVar.current.value[0] === '$__all')
+      if (myVar.current.value === '$__all' || myVar.current.value.length === 1 && myVar.current.value[0] === '$__all')
       {
         if (myVar.allValue !== null)
           value = myVar.allValue;
@@ -318,7 +318,7 @@ export default class Warp10Datasource {
   private scopedVarIsAll(name: string): boolean {
     for (let i = 0; i < this.templateSrv.variables.length; i++) {
       const v = this.templateSrv.variables[i]
-      if (v.name === name && v.current.value.length === 1 && v.current.value[0] === '$__all') {
+      if (v.current.value === '$__all' || v.name === name && v.current.value.length === 1 && v.current.value[0] === '$__all') {
         return true
       }
     }


### PR DESCRIPTION
I found something strange today when playing with dashboards relying on many `All` values. And once again, I realized how inconsistent Grafana is: sometimes, an `All` value is stored as `'$__all'`, sometimes it is stored as `['$__all']`. This commit now allows the proper detection of both cases.