### PR TITLE
fix: Load ace syntax hints when possible (with setTimeout)

### DIFF
--- a/dist/ace-mode-warpscript.d.ts
+++ b/dist/ace-mode-warpscript.d.ts
@@ -1,1 +1,1 @@
-export default function (): void;
+export default function (): boolean;

--- a/dist/ace-mode-warpscript.js
+++ b/dist/ace-mode-warpscript.js
@@ -157,6 +157,7 @@ System.register([], function (exports_1, context_1) {
                     content: '<% ${1:true} %>\n\t<% ${2:} %>\n\t<% ${3:} %>\nIFTE \n'
                 }];
         });
+        return true;
     }
     exports_1("default", default_1);
     return {

--- a/dist/warp10-query.controller.js
+++ b/dist/warp10-query.controller.js
@@ -16,6 +16,11 @@ System.register(["app/plugins/sdk", "./query", "./ace-mode-warpscript"], functio
     })();
     var sdk_1, query_1, ace_mode_warpscript_1, Warp10QueryCtrl;
     var __moduleName = context_1 && context_1.id;
+    function initAce() {
+        if (!ace_mode_warpscript_1.default()) {
+            setTimeout(initAce, 500);
+        }
+    }
     return {
         setters: [
             function (sdk_1_1) {
@@ -29,7 +34,7 @@ System.register(["app/plugins/sdk", "./query", "./ace-mode-warpscript"], functio
             }
         ],
         execute: function () {///<reference path="../node_modules/grafana-sdk-mocks/app/headers/common.d.ts" />
-            ace_mode_warpscript_1.default();
+            initAce();
             Warp10QueryCtrl = /** @class */ (function (_super) {
                 __extends(Warp10QueryCtrl, _super);
                 function Warp10QueryCtrl($scope, uiSegmentSrv, $injector) {

--- a/src/ace-mode-warpscript.ts
+++ b/src/ace-mode-warpscript.ts
@@ -170,4 +170,5 @@ export default function() {
       content: '<% ${1:true} %>\n\t<% ${2:} %>\n\t<% ${3:} %>\nIFTE \n'
     }]
   })
+  return true
 }

--- a/src/warp10-query.controller.ts
+++ b/src/warp10-query.controller.ts
@@ -4,7 +4,12 @@ import { QueryCtrl }   from 'app/plugins/sdk'
 import Query from './query'
 import initWarp10AceMode from './ace-mode-warpscript'
 
-initWarp10AceMode()
+function initAce () {
+  if (! initWarp10AceMode()) {
+    setTimeout(initAce, 500);
+  }
+}
+initAce()
 
 export default class Warp10QueryCtrl extends QueryCtrl {
 


### PR DESCRIPTION
ACE is loaded in async mode, this is the only way for now to "check" ace is loaded.

Fix syntax highlighting in Grafana 6.X context.