### PR TITLE
Console output of the full query, with headers

### DIFF
--- a/dist/gts.d.ts
+++ b/dist/gts.d.ts
@@ -5,7 +5,7 @@ export default class GTS {
     la?: number;
     v: any[][];
     constructor();
-    readonly nameWithLabels: string;
+    get nameWithLabels(): string;
     /**
      * Determine if an object is a GTS
      * @param {Object} g object to test
@@ -28,5 +28,5 @@ export default class GTS {
      * Return all GTS attributes
      * @return {string} all GTS
      */
-    readonly formatedAttributes: string;
+    get formatedAttributes(): string;
 }

--- a/dist/query.d.ts
+++ b/dist/query.d.ts
@@ -32,5 +32,5 @@ export default class Warp10Query {
     addFilterParamMapLabel(key: string, val: string): void;
     delFilterParamMapLabel(key: string): void;
     private static formatStringVar;
-    readonly warpScript: string;
+    get warpScript(): string;
 }

--- a/dist/warp10-datasource.js
+++ b/dist/warp10-datasource.js
@@ -46,7 +46,7 @@ System.register(["./gts", "./table", "./geo", "./query"], function (exports_1, c
                                 query.advancedMode = true;
                             query.ws = wsHeader + "\n" + (query.advancedMode ? query.expr : query.friendlyQuery.warpScript);
                             queries.push(query);
-                            console.debug('New Query: ', (query.advancedMode) ? query.expr : query.friendlyQuery);
+                            console.debug('New Query: ', query.ws);
                         }
                         //}
                     });

--- a/src/warp10-datasource.ts
+++ b/src/warp10-datasource.ts
@@ -32,7 +32,7 @@ export default class Warp10Datasource {
           query.advancedMode = true
         query.ws = `${wsHeader}\n${query.advancedMode ? query.expr : query.friendlyQuery.warpScript}`
         queries.push(query)
-        console.debug('New Query: ', (query.advancedMode) ? query.expr : query.friendlyQuery)
+        console.debug('New Query: ', query.ws)
       }
       //}
     })


### PR DESCRIPTION
Just changed the console output for a better understanding of WarpScript substitutions.

For example, multiple selection on a variable are translated in a string separated by `+` in WarpScript:
![image](https://user-images.githubusercontent.com/37228740/71625738-b3139200-2be9-11ea-8175-b02a245e4e78.png)

This is not obvious... 